### PR TITLE
Add DSL for creating menu toolbar

### DIFF
--- a/src/main/kotlin/data/local/model/menu/Rules.kt
+++ b/src/main/kotlin/data/local/model/menu/Rules.kt
@@ -7,27 +7,28 @@ import kotools.types.text.toNotBlankString
 
 /*
 Toolbar = Set<Menu>
-Menu = Label + NotEmptySet<MenuOption>
-MenuOption = Label + (Action | NotEmptySet<MenuOption>)
-ActionableOption = Label + Action
-Label = NotBlankString
+MenuOption = Menu | RunnableMenuOption
+Menu = MenuOptionLabel + NotEmptySet<MenuOption>
+MenuLabel = "File" | "Help"
+RunnableMenuOption = MenuOptionLabel + Action
+RunnableMenuOptionLabel = "New Window" | "Exit" | "About"
 Action = () -> Unit
  */
 
 private fun main() {
     MenuToolbar(
         Menu(
-            label = "File".toNotBlankString().getOrThrow(),
-            RunnableMenuOption("New Window".toNotBlankString().getOrThrow()) {
+            MenuOptionLabel.File,
+            RunnableMenuOption(MenuOptionLabel.NewWindow) {
                 Timber.d("onClick() : New Window")
             },
-            RunnableMenuOption("Exit".toNotBlankString().getOrThrow()) {
+            RunnableMenuOption(MenuOptionLabel.Exit) {
                 Timber.d("onClick(): Exit")
             }
         ),
         Menu(
-            label = "Help".toNotBlankString().getOrThrow(),
-            RunnableMenuOption("About".toNotBlankString().getOrThrow()) {
+            MenuOptionLabel.Help,
+            RunnableMenuOption(MenuOptionLabel.About) {
                 Timber.d("Click on 'About'.")
             }
         )
@@ -43,11 +44,25 @@ interface MenuToolbar {
 }
 
 sealed interface MenuOption {
-    val label: NotBlankString
+    val label: MenuOptionLabel
+}
+
+enum class MenuOptionLabel(private val value: String) {
+    About("About"),
+    Exit("Exit"),
+    File("File"),
+    Help("Help"),
+    NewWindow("New Window");
+
+    fun toNotBlankString(): NotBlankString = value.toNotBlankString()
+        .getOrNull()
+        ?: error("Converting '$value' to NotBlankString shouldn't fail.")
+
+    override fun toString(): String = value
 }
 
 fun Menu(
-    label: NotBlankString,
+    label: MenuOptionLabel,
     option: MenuOption,
     vararg otherOptions: MenuOption
 ): Menu {
@@ -59,7 +74,7 @@ interface Menu : MenuOption {
 }
 
 fun RunnableMenuOption(
-    label: NotBlankString,
+    label: MenuOptionLabel,
     action: () -> Unit
 ): RunnableMenuOption {
     TODO()

--- a/src/main/kotlin/data/local/model/menu/Rules.kt
+++ b/src/main/kotlin/data/local/model/menu/Rules.kt
@@ -1,0 +1,71 @@
+package data.local.model.menu
+
+import core.log.Timber
+import kotools.types.collection.NotEmptySet
+import kotools.types.text.NotBlankString
+import kotools.types.text.toNotBlankString
+
+/*
+Toolbar = Set<Menu>
+Menu = Label + NotEmptySet<MenuOption>
+MenuOption = Label + (Action | NotEmptySet<MenuOption>)
+ActionableOption = Label + Action
+Label = NotBlankString
+Action = () -> Unit
+ */
+
+private fun main() {
+    MenuToolbar(
+        Menu(
+            label = "File".toNotBlankString().getOrThrow(),
+            RunnableMenuOption("New Window".toNotBlankString().getOrThrow()) {
+                Timber.d("onClick() : New Window")
+            },
+            RunnableMenuOption("Exit".toNotBlankString().getOrThrow()) {
+                Timber.d("onClick(): Exit")
+            }
+        ),
+        Menu(
+            label = "Help".toNotBlankString().getOrThrow(),
+            RunnableMenuOption("About".toNotBlankString().getOrThrow()) {
+                Timber.d("Click on 'About'.")
+            }
+        )
+    )
+}
+
+fun MenuToolbar(vararg menus: Menu): MenuToolbar {
+    TODO()
+}
+
+interface MenuToolbar {
+    val menus: Set<Menu>
+}
+
+sealed interface MenuOption {
+    val label: NotBlankString
+}
+
+fun Menu(
+    label: NotBlankString,
+    option: MenuOption,
+    vararg otherOptions: MenuOption
+): Menu {
+    TODO()
+}
+
+interface Menu : MenuOption {
+    val options: NotEmptySet<MenuOption>
+}
+
+fun RunnableMenuOption(
+    label: NotBlankString,
+    action: () -> Unit
+): RunnableMenuOption {
+    TODO()
+}
+
+// 2 actionable options are equals if there have the same label.
+interface RunnableMenuOption : MenuOption {
+    operator fun invoke()
+}


### PR DESCRIPTION
## Description

This request adds a DSL for creating the menu toolbar of the desktop application.
It is marked as draft for reviewing the requirements and the API of the DSL.

## Requirements

- A menu toolbar has at least one menu.
- A menu has a label and at least one option.
- A menu label shouldn't be blank.
- A menu option can be a menu or an actionable option.
- An actionable option has a label and an action to execute on click.
- An actionable option label shouldn't be blank.

```kotlin
import kotools.types.NotEmptySet
import kotools.types.NotBlankString

interface MenuToolbar {
    val menus: NotEmptySet<Menu>
}

sealed interface MenuOption {
    val label: NotBlankString
}

interface Menu : MenuOption {
    val options: NotEmptySet<MenuOption>
}

interface ActionableOption : MenuOption {
    fun onClick(): Unit
}
```

> If we already know the labels of menu options at compile-time, we should define them in sealed hierarchies (`enum class` or `sealed interface` for example).

## Checklist

- [x] Validate the requirements.
- [ ] Define the DSL without implementing the declarations.
- [ ] Implement and test the `ActionableOption` type.
- [ ] Implement and test the `Menu` type.
- [ ] Implement and test the `MenuOption` type.
- [ ] Implement and test the `MenuToolbar` type.
- [ ] Refactor code for using this new DSL.